### PR TITLE
feat: add animation fill mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ const pluginCreator = api => {
 
   const dynamicUtils = {
     'animate-delay': { css: 'animation-delay', values: theme('animationDelay') },
-    'animate-duration': { css: 'animation-duration', values: theme('animationDuration') }
+    'animate-duration': { css: 'animation-duration', values: theme('animationDuration') },
+    'animate-fill-mode': { css: 'animation-fill-mode', values: theme('animationFillMode') },
   }
 
   Object.entries(dynamicUtils).forEach(([name, { css, values }]) => {

--- a/src/theme.js
+++ b/src/theme.js
@@ -448,5 +448,11 @@ export default {
     500: '500ms',
     700: '700ms',
     1000: '1000ms'
-  }
+  },
+  animationFillMode: {
+    none: 'none',
+    forwards: 'forwards',
+    backwards: 'backwards',
+    both: 'both'
+  },
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -60,7 +60,7 @@ describe('tailwindcss-animations plugins', () => {
 
   it('use a fill mode animation', async () => {
     const css = await generatePluginCSS({
-      content: '<div class="animate-zoom-in animate-fill-mode-forwards">Hello</div>'
+      content: '<div class="animate-fill-mode-forwards">Hello</div>'
     })
 
     expect(css).toMatch('.animate-fill-mode-forwards{animation-fill-mode:forwards}')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -57,4 +57,12 @@ describe('tailwindcss-animations plugins', () => {
 
     expect(css).toMatch('.animate-linear{animation-timing-function:linear}')
   })
+
+  it('use a fill mode animation', async () => {
+    const css = await generatePluginCSS({
+      content: '<div class="animate-zoom-in animate-fill-mode-forwards">Hello</div>'
+    })
+
+    expect(css).toMatch('.animate-fill-mode-forwards{animation-fill-mode:forwards}')
+  })
 })


### PR DESCRIPTION
### Descripción
Se agrega la utilidad de `animate-fill-mode` con los valores:
- none
- forwards
- backwards
- both

### Ejemplo de uso
```jsx
<div class="animate-fill-mode-forwards">Hello</div>
```