### PR TITLE
fix: fixed the broken readme image in spanish

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -9,7 +9,7 @@
 ![GitHub PRs](https://img.shields.io/github/issues-pr/midudev/tailwind-animations)
 ![GitHub issues](https://img.shields.io/github/issues/midudev/tailwind-animations)
 
-![web](./lib/imgs/web.png)
+![web](./lib/imgs/web.jpg)
 
 ![Tailwind
 CSS](https://img.shields.io/badge/Tailwind%20CSS-2.2.7-blue?style=for-the-badge&logo=tailwind-css)


### PR DESCRIPTION
This is what it looks like now: 
![image](https://github.com/midudev/tailwind-animations/assets/83567373/a031b6f8-a6f3-4340-88e0-32f7fc045a41)

after the change:
![image](https://github.com/midudev/tailwind-animations/assets/83567373/264537d1-b8a6-4aea-b8b8-9c3aab8831c0)
