### PR TITLE
Mejoras en las funciones de copiado, actualizacion del readme y configuracion de prettier y eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 pnpm-lock.yaml
+bun.lockb

--- a/README.es.md
+++ b/README.es.md
@@ -12,8 +12,8 @@
 ![web](./lib/imgs/web.png)
 
 ![Tailwind
-CSS](https://img.shields.io/badge/Tailwind%20CSS-2.2.7-blue?style=for-the-badge&logo=tailwind-css)
-![Astro](https://img.shields.io/badge/Astro-0.23.0-blue?style=for-the-badge&logo=astro)
+CSS](https://img.shields.io/badge/Tailwind%20CSS-3.4.1-blue?style=for-the-badge&logo=tailwind-css)
+![Astro](https://img.shields.io/badge/Astro-4.3.3-blue?style=for-the-badge&logo=astro)
 
 <!-- Get your animations easily done with only Tailwind CSS classes. -->
 Obten animaciones de CSS con una sola clase de Tailwind!

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 ![web](./lib/imgs/web.jpg)
 
 ![Tailwind
-CSS](https://img.shields.io/badge/Tailwind%20CSS-2.2.7-blue?style=for-the-badge&logo=tailwind-css)
-![Astro](https://img.shields.io/badge/Astro-0.23.0-blue?style=for-the-badge&logo=astro)
+CSS](https://img.shields.io/badge/Tailwind%20CSS-3.4.1-blue?style=for-the-badge&logo=tailwind-css)
+![Astro](https://img.shields.io/badge/Astro-4.3.3-blue?style=for-the-badge&logo=astro)
 
 Get your animations easily done with only Tailwind CSS classes.
 

--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -1,6 +1,6 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
-  extends: ['plugin:astro/recommended'],
+  extends: ['plugin:astro/recommended', 'prettier'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     tsconfigRootDir: __dirname,

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -12,6 +12,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+bun.lockb*
 
 # environment variables
 .env

--- a/web/.prettierrc.cjs
+++ b/web/.prettierrc.cjs
@@ -1,7 +1,10 @@
 /** @type {import("prettier").Config} */
 module.exports = {
   ...require('prettier-config-standard'),
-  plugins: [require.resolve('prettier-plugin-astro')],
+  plugins: [
+    require.resolve('prettier-plugin-astro'),
+    'prettier-plugin-tailwindcss'
+  ],
   overrides: [
     {
       files: '*.astro',

--- a/web/.vscode/settings.json
+++ b/web/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "eslint.validate": [
+    "javascript",
+    "astro", 
+    "typescript",
+  ],
+  "prettier.documentSelectors": ["**/*.astro"],
+  "[astro]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "always"
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -21,10 +21,12 @@
   "devDependencies": {
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.56.0",
+    "eslint-config-prettier": "9.1.0",
     "eslint-plugin-astro": "^0.31.4",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "prettier": "^3.2.5",
     "prettier-config-standard": "^7.0.0",
-    "prettier-plugin-astro": "^0.13.0"
+    "prettier-plugin-astro": "^0.13.0",
+    "prettier-plugin-tailwindcss": "0.5.11"
   }
 }

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -4,7 +4,6 @@ import Layout from '@layouts/Layout.astro'
 import theme from '../../../src/theme.js'
 
 import CopyIcon from '@components/icons/copy.astro'
-import Copy from '@components/icons/copy.astro'
 
 const { animation } = theme
 ---
@@ -32,10 +31,10 @@ const { animation } = theme
             <code>npm install @midudev/tailwind-animations</code>
           </pre>
           <button
+            id='copyNpmInstall'
             class='inline-flex items-center justify-center whitespace-nowrap rounded-full bg-white/10 text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none size-7'
-            onclick="navigator.clipboard.writeText('npm install @midudev/tailwind-animations'); alert('Shipped into the clipboard :D ⛵');"
           >
-            <Copy />
+            <CopyIcon />
           </button>
         </div>
       </div>
@@ -48,17 +47,14 @@ const { animation } = theme
         Object.keys(animation).map((animationKey) => {
           return (
             <article
-              class='animate-duration-1000 col-span-1 border rounded border-gray-200 hover:border-gray-400 hover:shadow transition cursor-crosshair relative bg-white/10 backdrop-blur-sm'
+              class='animate-duration-1000 col-span-1 border rounded border-gray-200 hover:border-gray-400 hover:shadow transition-colors cursor-crosshair relative bg-white/10 backdrop-blur-sm'
               data-class={animationKey}
             >
               <div class='p-4 flex gap-4 items-center justify-center flex-col w-full h-full'>
                 <span class='w-16 h-16 bg-zinc-600 rounded-md flex items-center justify-center' />
-                <h3 class='font-semibold text-xs opacity-80'>{animationKey}</h3>
+                <p class='font-semibold text-sm opacity-80'>{animationKey}</p>
               </div>
-              <button
-                class='absolute top-1 right-2'
-                onclick={`navigator.clipboard.writeText('animate-${animationKey}'); `}
-              >
+              <button class='absolute top-2 right-2'>
                 <CopyIcon />
               </button>
             </article>
@@ -102,17 +98,26 @@ const { animation } = theme
     })
 
     $article.addEventListener('click', () => {
-      const animationKey = $article.getAttribute('data-class')
-      const CLASS_PREFIX = 'animate-'
-      const ANIMATION_TO_COPY = CLASS_PREFIX + animationKey
-
-      navigator.clipboard.writeText(ANIMATION_TO_COPY)
-
+      navigator.clipboard.writeText(animationClass)
       toast('Copied to clipboard!', {
         theme: {
           type: 'light'
         }
       })
+    })
+  })
+
+  const $copyNpmInstall = document.getElementById(
+    'copyNpmInstall'
+  ) as HTMLButtonElement
+
+  $copyNpmInstall.addEventListener('click', () => {
+    const npmCommand = 'npm install @midudev/tailwind-animations'
+    navigator.clipboard.writeText(npmCommand)
+    toast('Copied to clipboard!', {
+      theme: {
+        type: 'light'
+      }
     })
   })
 </script>


### PR DESCRIPTION
1. Se agrego la configuracion para vscode de eslint y prettier para que funcione con Astro
2. Se agrego el plugin de prettier para tailwindcss con el fin de mantener el mismo estilo de clases
3. Se actualizo la version de las badge de Tailwind y Astro en el Readme en sus ambas versiones
4. Se cambio de text-xs a text-sm en los articles de las animaciones
5. Se cambio de transition a transition-colors en los article 