### PR TITLE
Arreglos en los archivos readme

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -15,7 +15,7 @@
 
 ![Tailwind
 CSS](https://img.shields.io/badge/Tailwind%20CSS-3.4.1-blue?style=for-the-badge&logo=tailwind-css)
-![Astro](https://img.shields.io/badge/Astro-4.3.3-blue?style=for-the-badge&logo=astro)
+![Astro](https://img.shields.io/badge/Astro-4.3.3-orange?style=for-the-badge&logo=astro)
 
 <!-- Get your animations easily done with only Tailwind CSS classes. -->
 Obten animaciones de CSS con una sola clase de Tailwind!

--- a/README.es.md
+++ b/README.es.md
@@ -6,14 +6,16 @@
 [![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
 
 ![GitHub stars](https://img.shields.io/github/stars/midudev/tailwind-animations)
+![GitHub Contributors](https://img.shields.io/github/contributors/midudev/tailwind-animations)
 ![GitHub PRs](https://img.shields.io/github/issues-pr/midudev/tailwind-animations)
 ![GitHub issues](https://img.shields.io/github/issues/midudev/tailwind-animations)
+![GitHub Contributors](https://img.shields.io/github/contributors/midudev/tailwind-animations)
 
-![web](./lib/imgs/web.png)
+![web](./lib/imgs/web.jpg)
 
 ![Tailwind
-CSS](https://img.shields.io/badge/Tailwind%20CSS-2.2.7-blue?style=for-the-badge&logo=tailwind-css)
-![Astro](https://img.shields.io/badge/Astro-0.23.0-blue?style=for-the-badge&logo=astro)
+CSS](https://img.shields.io/badge/Tailwind%20CSS-3.4.1-blue?style=for-the-badge&logo=tailwind-css)
+![Astro](https://img.shields.io/badge/Astro-4.3.3-blue?style=for-the-badge&logo=astro)
 
 <!-- Get your animations easily done with only Tailwind CSS classes. -->
 Obten animaciones de CSS con una sola clase de Tailwind!

--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@
 [![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
 
 ![GitHub stars](https://img.shields.io/github/stars/midudev/tailwind-animations)
+![GitHub Contributors](https://img.shields.io/github/contributors/midudev/tailwind-animations)
 ![GitHub PRs](https://img.shields.io/github/issues-pr/midudev/tailwind-animations)
 ![GitHub issues](https://img.shields.io/github/issues/midudev/tailwind-animations)
+![GitHub Contributors](https://img.shields.io/github/contributors/midudev/tailwind-animations)
 
 ![web](./lib/imgs/web.jpg)
 
 ![Tailwind
-CSS](https://img.shields.io/badge/Tailwind%20CSS-2.2.7-blue?style=for-the-badge&logo=tailwind-css)
-![Astro](https://img.shields.io/badge/Astro-0.23.0-blue?style=for-the-badge&logo=astro)
+CSS](https://img.shields.io/badge/Tailwind%20CSS-3.4.1-blue?style=for-the-badge&logo=tailwind-css)
+![Astro](https://img.shields.io/badge/Astro-4.3.3-blue?style=for-the-badge&logo=astro)
 
 Get your animations easily done with only Tailwind CSS classes.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ![Tailwind
 CSS](https://img.shields.io/badge/Tailwind%20CSS-3.4.1-blue?style=for-the-badge&logo=tailwind-css)
-![Astro](https://img.shields.io/badge/Astro-4.3.3-blue?style=for-the-badge&logo=astro)
+![Astro](https://img.shields.io/badge/Astro-4.3.3-orange?style=for-the-badge&logo=astro)
 
 Get your animations easily done with only Tailwind CSS classes.
 


### PR DESCRIPTION
Hacía falta arreglar las versiones de Tailwind y Astro junto con arreglar el link de la imagen para la versión en español

Antes:

![image](https://github.com/midudev/tailwind-animations/assets/35697365/5b6f5f45-8be5-4114-828d-3f77be5a37d0)

Ahora:

![image](https://github.com/midudev/tailwind-animations/assets/35697365/ebfafdcf-01f4-4002-955c-504bf9c3a134)
