### PR TITLE
Corregida URL del website en README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ CSS](https://img.shields.io/badge/Tailwind%20CSS-3.4.1-blue?style=for-the-badge&
 
 Get your animations easily done with only Tailwind CSS classes.
 
-Visit the [website](https://github.com/midudev/tailwind-animations) to get more information.
+Visit the [website](https://tailwindcss-animations.vercel.app/) to get more information.
 </div>
   
 ## Installation :book:
@@ -27,8 +27,6 @@ Visit the [website](https://github.com/midudev/tailwind-animations) to get more 
 #### Package install
 
 > Install the package with your favorite package manager:
-=======
-Visit the [website](https://tailwindcss-animations.vercel.app/) to get more information.
 
 - npm
 ```bash


### PR DESCRIPTION
Anteriormente, además de estar duplicada, apuntaba a el repositorio de github, en lugar del sitio web.

Antes:
![imagen](https://github.com/midudev/tailwind-animations/assets/62667318/e19d04b1-1766-43a2-9ca6-889e5e6dbb70)

Ahora:
![imagen](https://github.com/midudev/tailwind-animations/assets/62667318/1525c861-41cb-4cfe-8b86-2cb8ad20028c)

Esto aporta coherencia con el README.es.md