### PR TITLE
Remove unused code

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -74,14 +74,6 @@ export default {
     'pulse-fade-in': 'pulse-fade-in 0.6s ease-out both'
   },
   keyframes: {
-    'background-shine': {
-      from: {
-        backgroundPosition: '0 0'
-      },
-      to: {
-        backgroundPosition: '-200% 0'
-      }
-    },
     'fade-in': {
       '0%': { opacity: '0' },
       '100%': { opacity: '1' }


### PR DESCRIPTION
In commit [Remove background shine ](https://github.com/midudev/tailwind-animations/commit/47b61cea67fef3fa7f4f79595eb5ee8e4471d323) it was removed

```javascript
'background-shine': 'background-shine 2s linear infinite both',
```

For that reason I removed the unused code.

```javascript
'background-shine': {
      from: {
        backgroundPosition: '0 0'
      },
      to: {
        backgroundPosition: '-200% 0'
      }
},
```

