### PR TITLE
Edited pulse animation, was malformed

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -147,8 +147,8 @@ export default {
       '100%': { transform: 'translateX(0)' }
     },
     pulse: {
-      '0%, 100%': { transform: 'opacity: 1' },
-      '50%': { transform: 'opacity: 0.5' }
+      '0%, 100%': { opacity: '1' },
+      '50%': { opacity: '0.5' }
     },
     pulsing: {
       '0%': { transform: 'scale(1)' },


### PR DESCRIPTION
**What does this PR do?**

The keyframe for the pulse animation was incorrect
changed transform : opacity 1 to opacity 1 and transform: opacity 0.5 to opacity: 0.5

This:
![image](https://github.com/midudev/tailwind-animations/assets/8560372/d01339e5-2220-494c-ac76-00880480faff)
To this:
![image](https://github.com/midudev/tailwind-animations/assets/8560372/c17f2d49-d941-4a27-9884-f1bb69d1bc62)
---
**Checklist**
- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated the docs
- [ ] Added a test