### PR TITLE
Add display: none; property to the animation keyframes for fade-out animations.

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -81,7 +81,7 @@ export default {
     },
     'fade-out': {
       '0%': { opacity: '1' },
-      '100%': { opacity: '0' }
+      '100%': { opacity: '0', display: 'none' }
     },
     'slide-in-top': {
       '0%': { transform: 'translateY(-20px)' },
@@ -93,11 +93,11 @@ export default {
     },
     'slide-out-top': {
       '0%': { transform: 'translateY(0)' },
-      '100%': { transform: 'translateY(-20px)' }
+      '100%': { transform: 'translateY(-20px)', display: 'none' }
     },
     'slide-out-bottom': {
       '0%': { transform: 'translateY(0)' },
-      '100%': { transform: 'translateY(20px)' }
+      '100%': { transform: 'translateY(20px)', display: 'none' }
     },
     'zoom-in': {
       '0%': { opacity: '0', transform: 'scale(.5)' },
@@ -105,7 +105,7 @@ export default {
     },
     'zoom-out': {
       '0%': { opacity: '1', transform: 'scale(1)' },
-      '100%': { opacity: '0', transform: 'scale(.5)' }
+      '100%': { opacity: '0', transform: 'scale(.5)', display: 'none' }
     },
     'rotate-90': {
       '0%': { transform: 'rotate(0deg)' },
@@ -191,7 +191,7 @@ export default {
     },
     'roll-out': {
       '0%': { transform: 'translateX(0) rotate(0)' },
-      '100%': { transform: 'translateX(20px) rotate(120deg)' }
+      '100%': { transform: 'translateX(20px) rotate(120deg)', display: 'none' }
     },
     float: {
       '0%': { transform: 'translateY(0)' },
@@ -232,11 +232,11 @@ export default {
     },
     'slide-out-left': {
       '0%': { transform: 'translateX(0)' },
-      '100%': { transform: 'translateX(-20px)' }
+      '100%': { transform: 'translateX(-20px)', display: 'none' }
     },
     'slide-out-right': {
       '0%': { transform: 'translateX(0)' },
-      '100%': { transform: 'translateX(20px)' }
+      '100%': { transform: 'translateX(20px)', display: 'none' }
     },
     'spin-clockwise': {
       '0%': { transform: 'rotate(0deg)' },
@@ -299,19 +299,19 @@ export default {
     },
     'fade-out-up': {
       '0%': { opacity: '1', transform: 'translateY(0)' },
-      '100%': { opacity: '0', transform: 'translateY(-20px)' }
+      '100%': { opacity: '0', transform: 'translateY(-20px)', display: 'none' }
     },
     'fade-out-down': {
       '0%': { opacity: '1', transform: 'translateY(0)' },
-      '100%': { opacity: '0', transform: 'translateY(20px)' }
+      '100%': { opacity: '0', transform: 'translateY(20px)', display: 'none' }
     },
     'fade-out-left': {
       '0%': { opacity: '1', transform: 'translateX(0)' },
-      '100%': { opacity: '0', transform: 'translateX(-20px)' }
+      '100%': { opacity: '0', transform: 'translateX(-20px)', display: 'none' }
     },
     'fade-out-right': {
       '0%': { opacity: '1', transform: 'translateX(0)' },
-      '100%': { opacity: '0', transform: 'translateX(20px)' }
+      '100%': { opacity: '0', transform: 'translateX(20px)', display: 'none' }
     },
     sway: {
       '0%': { transform: 'rotate(0deg)' },
@@ -328,11 +328,11 @@ export default {
     },
     'flip-out-x': {
       '0%': { opacity: '1', transform: 'rotateY(0deg)' },
-      '100%': { opacity: '0', transform: 'rotateY(90deg)' }
+      '100%': { opacity: '0', transform: 'rotateY(90deg)', display: 'none' }
     },
     'flip-out-y': {
       '0%': { opacity: '1', transform: 'rotateX(0deg)' },
-      '100%': { opacity: '0', transform: 'rotateX(90deg)' }
+      '100%': { opacity: '0', transform: 'rotateX(90deg)', display: 'none' }
     },
     'rotate-in': {
       '0%': { opacity: '0', transform: 'rotate(-90deg)' },
@@ -340,7 +340,7 @@ export default {
     },
     'rotate-out': {
       '0%': { opacity: '1', transform: 'rotate(0deg)' },
-      '100%': { opacity: '0', transform: 'rotate(90deg)' }
+      '100%': { opacity: '0', transform: 'rotate(90deg)', display: 'none' }
     },
     'slide-rotate-in': {
       '0%': { opacity: '0', transform: 'translateX(-20px) rotate(-90deg)' },
@@ -348,7 +348,7 @@ export default {
     },
     'slide-rotate-out': {
       '0%': { opacity: '1', transform: 'translateX(0) rotate(0deg)' },
-      '100%': { opacity: '0', transform: 'translateX(20px) rotate(90deg)' }
+      '100%': { opacity: '0', transform: 'translateX(20px) rotate(90deg)', display: 'none' }
     },
     heartbeat: {
       '0%': { transform: 'scale(1)' },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -136,4 +136,11 @@ describe('tailwindcss-animations plugins', () => {
 
     expect(css).toMatch('.animate-play-paused{animation-play-state:paused}')
   })
+
+  it('use fade out animation', async () => {
+    const css = await generatePluginCSS({
+      content: '<div class="animate-fade-out">Hello</div>'
+    })
+    expect(css).toMatch('@keyframes fade-out{0%{opacity:1}100%{opacity:0;display:none}}.animate-fade-out{animation:fade-out 0.6s ease-out both}')
+  })
 })


### PR DESCRIPTION
**What does this PR do?**


This PR adds the display: none; property to the animation keyframes for fade-out animations. This change ensures that elements using fade-out animations are properly hidden after the animation completes.

**Why are we doing this?**

Previously, the fade-out animations didn't explicitly set the display property, which could lead to elements remaining visible in the DOM after the animation completed. By adding display: none; to the animation keyframes, we ensure that elements are properly hidden once the animation finishes.

---
**Test Case(s):**

 Added a test to verify the behavior of fade-out animation.

  ```javascript
  it('use fade out animation', async () => {
    const css = await generatePluginCSS({
      content: '<div class="animate-fade-out">Hello</div>'
    })
    expect(css).toMatch('@keyframes fade-out{0%{opacity:1}100%{opacity:0;display:none}}.animate-fade-out{animation:fade-out 0.6s ease-out both}')
  })
```

**Test Result(s):**

✓ tailwindcss-animations plugins (18) 1622ms
     ✓ use a predefined animation
     ✓ use fade in up animation
     ✓ use a predefined animation delay
     ✓ use a custom animation delay
     ✓ use a predefined animation duration
     ✓ use a predefined named animation duration
     ✓ use a custom animation duration
     ✓ use a timing function animation
     ✓ use a bezier curve as a timing function animation
     ✓ use a custom bezier curve as a timing function animation
     ✓ use a custom animation iteration count
     ✓ use a custom animation iteration count with an arbitrary value
     ✓ use a custom animation direction
     ✓ use a fill mode animation
     ✓ use not custom animation steps
     ✓ use a custom animation steps
     ✓ use a play state animation play
     ✓ use fade out animation

---
**Checklist**
- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated the docs
- [x] Added a test