### PR TITLE
style(web): 📱 fixed grid styles on select buttons to keep the responsive design

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -88,7 +88,7 @@ export default {
         <span class='ms-3 text-xl font-medium text-gray-900 dark:text-gray-100'>Animate all</span>
       </label>
     </section>  
-    <section class='mb-6 grid grid-flow-col gap-6 columns-4 items-center justify-center'>
+    <section class='mb-6 grid md:grid-flow-col grid-flow-row gap-6 columns-4 items-center justify-center'>
       <label for="duration" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
         Duration
         <select name="duration" id="duration" class="mt-2 bg-gray-50 min-w-36 border border-gray-300 text-gray-900 text-sm rounded-lg block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white">


### PR DESCRIPTION
**What does this PR do?**

Fix responsive

**Why are we doing this?**

The select buttons were breaking the responsive

---
# Previews before

### Mobile
<img width="50%" alt="Screenshot 2024-02-24 at 21 54 41" src="https://github.com/midudev/tailwind-animations/assets/37640685/2bbf3ed4-ec7e-4758-b972-39a1958667df">

# Previews after

### Mobile
<img width="50%" alt="image" src="https://github.com/midudev/tailwind-animations/assets/37640685/ef87de72-3b50-4a4f-9449-f2e37f655341">

### Desktop
<img width="100%" alt="image" src="https://github.com/midudev/tailwind-animations/assets/37640685/7dd1ebb1-ac3e-4705-88ec-acc9d26dfdeb">

---
**Checklist**
- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated the docs
- [ ] Added a test