### PR TITLE
Fix: website toggle theme click not open

### DIFF
--- a/web/src/components/ToggleTheme.astro
+++ b/web/src/components/ToggleTheme.astro
@@ -22,7 +22,7 @@ const THEMES = ["Light", "Dark", "System"]
   </button>
   <div
     id="themes-menu"
-    class="absolute opacity-0 scale-80 top-8 right-0 text-sm p-1 min-w-[8rem] rounded-md border border-gray-100 bg-white/90 dark:bg-zinc-900/70 dark:border-gray-500/20 shadow-[0_3px_10px_rgb(0,0,0,0.2)] backdrop-blur-md z-50"
+    class="absolute opacity-0 hidden scale-80 top-8 right-0 text-sm p-1 min-w-[8rem] rounded-md border border-gray-100 bg-white/90 dark:bg-zinc-900/70 dark:border-gray-500/20 shadow-[0_3px_10px_rgb(0,0,0,0.2)] backdrop-blur-md z-50"
   >
     <ul>
       {
@@ -39,6 +39,7 @@ const THEMES = ["Light", "Dark", "System"]
 <style>
   #themes-menu.open {
     animation: scale-up-center 0.15s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+    display: block;
   }
 
   @keyframes scale-up-center {


### PR DESCRIPTION
Currently the toggle theme, when closed, is clickable and switches themes.

I have added a display:none when closed and a display:open when open.

