### PR TITLE
fix: typescript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 pnpm-lock.yaml
 bun.lockb
 package-lock.json
+dist

--- a/package.json
+++ b/package.json
@@ -2,9 +2,20 @@
   "name": "@midudev/tailwind-animations",
   "version": "0.0.7",
   "description": "Tailwind CSS plugin to add animations to your website",
-  "main": "./src/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./src/index.js"
+    },
+    "./theme": {
+      "require": "./dist/theme.js",
+      "import": "./src/theme.js"
+    }
+  },
   "scripts": {
+    "build": "tsc",
     "lint": "standard ./src",
     "lint:fix": "standard --fix ./src",
     "test": "vitest",
@@ -14,10 +25,11 @@
   "author": "Miguel Ángel Durán (@midudev) & su maravillosa comunidad",
   "license": "MIT",
   "devDependencies": {
+    "@csstools/postcss-minify": "1.1.0",
     "postcss": "8.4.35",
     "standard": "17.1.0",
     "tailwindcss": "3.4.1",
-    "@csstools/postcss-minify": "1.1.0",
+    "typescript": "^5.4.5",
     "vitest": "1.2.2"
   },
   "peerDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "include": ["src/**/*"],
+    "compilerOptions": {
+      "allowJs": true,
+      "declaration": true,
+      "outDir": "dist",
+      "module": "commonjs",
+      "declarationMap": true,
+      "esModuleInterop": true
+    }
+  }

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "wc-toast": "1.3.1"
   },
   "devDependencies": {
+    "@midudev/tailwind-animations": "workspace:../",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "9.1.0",

--- a/web/tailwind.config.mjs
+++ b/web/tailwind.config.mjs
@@ -1,5 +1,5 @@
-import animations from '../src/index.js'
-import theme from '../src/theme.js'
+import animations from '@midudev/tailwind-animations'
+import theme from '@midudev/tailwind-animations/theme'
 
 const { animation } = theme
 


### PR DESCRIPTION
**What does this PR do?**
This PR is **adding support for _typescript_ and _commonjs_.**

Based on the [documentation](https://tailwindcss.com/docs/configuration#using-esm-or-type-script) tailwindcss config could be written in commonjs, esmodule and typescript. This module is only supporting esmodule for now.


---
**Checklist**
- [x] Tested locally
- [x] Added new dependencies
- [ ] Updated the docs
- [ ] Added a test