### PR TITLE
feat: add "jelly" animation

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -76,7 +76,8 @@ export default {
     'impulse-rotation-right': 'impulse-rotation-right 1s ease-in-out both',
     'impulse-rotation-left': 'impulse-rotation-left 1s ease-in-out both',
     dancing: 'dancing 1s ease-in-out both',
-    pulse: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite'
+    pulse: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+    jelly: `jelly 0.5s ease-out forwards`,
   },
   keyframes: {
     'fade-in': {
@@ -437,7 +438,13 @@ export default {
       '50%': { transform: 'skew(40deg)' },
       '75%': { transform: 'skew(-40deg)' },
       '100%': { transform: 'skew(0deg)' }
-    }
+    },
+    jelly: {
+      '0%': {transform: 'scale(1, 1)'},
+      '40%': {transform: 'scale(1.1, 0.9)'},
+      '80%': {transform: 'scale(0.95, 1.05)'},
+      '100%': {transform: 'scale(1, 1)'},
+    },
   },
   animationDelay: {
     none: '0ms',

--- a/src/theme.js
+++ b/src/theme.js
@@ -77,7 +77,7 @@ export default {
     'impulse-rotation-left': 'impulse-rotation-left 1s ease-in-out both',
     dancing: 'dancing 1s ease-in-out both',
     pulse: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
-    jelly: `jelly 0.5s ease-out forwards`,
+    jelly: `jelly 1s ease-out forwards`,
   },
   keyframes: {
     'fade-in': {
@@ -440,10 +440,14 @@ export default {
       '100%': { transform: 'skew(0deg)' }
     },
     jelly: {
-      '0%': {transform: 'scale(1, 1)'},
-      '40%': {transform: 'scale(1.1, 0.9)'},
-      '80%': {transform: 'scale(0.95, 1.05)'},
-      '100%': {transform: 'scale(1, 1)'},
+      '0%': { transform: 'scale(1, 1)' },
+      '20%': { transform: 'scale(1.25, 0.75)' }, 
+      '40%': { transform: 'scale(0.75, 1.25)' }, 
+      '60%': { transform: 'scale(1.15, 0.85)' },  
+      '75%': { transform: 'scale(0.95, 1.05)' }, 
+      '85%': { transform: 'scale(1.05, 0.95)' },  
+      '92%': { transform: 'scale(1, 1.02)' },   
+      '100%': { transform: 'scale(1, 1)' },    
     },
   },
   animationDelay: {


### PR DESCRIPTION
**What does this PR do?**
This PR adds a new animation named jelly to the Tailwind CSS animation utilities. The jelly animation gives a jelly-like effect where the element scales up and down in a springy fashion, making it look elastic and bouncy.

**Why are we doing this?**
We are adding the jelly animation to provide developers with more variety and flexibility in animation options within Tailwind CSS. This animation can be particularly useful for elements that need a playful or attention-grabbing effect, such as buttons, icons, or loading indicators. The jelly animation enhances user experience by adding dynamic visual feedback, making web interfaces feel more interactive and engaging.

---
**Test Case(s):**
Apply the animate-jelly class to a button element and verify the jelly animation effect on hover.

**Test Result(s):**
The button element correctly displays the jelly animation on hover, scaling smoothly in and out as expected.

---
**Checklist**
- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated the docs
- [ ] Added a test