### PR TITLE
Feature/new anim skew right

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -65,6 +65,7 @@ export default {
     'horizontal-vibration': 'horizontal-vibration 0.3s linear infinite both',
     'rotational-wave': 'rotational-wave 2s ease-in-out infinite both',
     skew: 'skew 0.5s ease-in-out both',
+    'skew-right': 'skew-right 0.5s ease-in-out both',
     'vertical-bounce': 'vertical-bounce 0.6s ease-in-out both',
     'horizontal-bounce': 'horizontal-bounce 0.6s ease-in-out both',
     tilt: 'tilt 0.6s ease-in-out both',
@@ -387,6 +388,10 @@ export default {
     skew: {
       '0%': { transform: 'skew(0deg)' },
       '100%': { transform: 'skew(20deg)' }
+    },
+    'skew-right': {
+      '0%': { transform: 'skew(0deg)' },
+      '100%': { transform: 'skew(-20deg)' }
     },
     'vertical-bounce': {
       '0%, 100%': { transform: 'translateY(0)' },

--- a/src/theme.js
+++ b/src/theme.js
@@ -78,7 +78,7 @@ export default {
     'impulse-rotation-left': 'impulse-rotation-left 1s ease-in-out both',
     dancing: 'dancing 1s ease-in-out both',
     pulse: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
-    jelly: `jelly 1s ease-out forwards`,
+    jelly: 'jelly 1s ease-out forwards'
   },
   keyframes: {
     'fade-in': {
@@ -446,14 +446,14 @@ export default {
     },
     jelly: {
       '0%': { transform: 'scale(1, 1)' },
-      '20%': { transform: 'scale(1.25, 0.75)' }, 
-      '40%': { transform: 'scale(0.75, 1.25)' }, 
-      '60%': { transform: 'scale(1.15, 0.85)' },  
-      '75%': { transform: 'scale(0.95, 1.05)' }, 
-      '85%': { transform: 'scale(1.05, 0.95)' },  
-      '92%': { transform: 'scale(1, 1.02)' },   
-      '100%': { transform: 'scale(1, 1)' },    
-    },
+      '20%': { transform: 'scale(1.25, 0.75)' },
+      '40%': { transform: 'scale(0.75, 1.25)' },
+      '60%': { transform: 'scale(1.15, 0.85)' },
+      '75%': { transform: 'scale(0.95, 1.05)' },
+      '85%': { transform: 'scale(1.05, 0.95)' },
+      '92%': { transform: 'scale(1, 1.02)' },
+      '100%': { transform: 'scale(1, 1)' }
+    }
   },
   animationDelay: {
     none: '0ms',


### PR DESCRIPTION
**What does this PR do?**
This PR adds a new animation called "skew-right" to the Tailwind CSS animation utilities. The "skew-right" animation creates an effect similar to "skew" but in the opposite direction, tilting the element to the right.

**Why are we doing this?**
We are adding the "skew-right" animation to provide developers with more variety and flexibility in animation options within Tailwind CSS. This animation can be particularly useful for elements that need a playful or attention-grabbing effect, such as containers, cards, or loading indicators. The "skew-right" animation enhances user experience by adding dynamic visual feedback, making web interfaces feel more interactive and engaging. 

---
**Test Case(s):**
Apply the animate-skew-right class to a button element and verify the "skew-right" animation effect on hover.

**Test Result(s):**
The button element correctly displays the "skew-right" animation on hover, tilting smoothly as expected.

---
**Checklist**
- [X] Tested locally
- [ ] Added new dependencies
- [ ] Updated the docs
- [ ] Added a test