### PR TITLE
fix: update guide for installation in tailwind

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -67,12 +67,9 @@ const { version } = pkg
         >
           <pre
             class='flex text-left text-xs'>
-            <Code wrap={true} theme="dark-plus" lang="js" code={`import animations from '@midudev/tailwind-animations'
-
-export default {
-  // ...rest of the options
-  plugins: [animations],
-}`} />
+            <Code wrap={true} theme="dark-plus" lang="js" code={`@import 'tailwindcss';
+...
+@plugin "@midudev/tailwind-animations";`} />
           </pre>
         </div>
       </div>


### PR DESCRIPTION
**What does this PR do?**
Simply update the guide for install the plugin following the new tailwind conventions

**Why are we doing this?**
Because new users are using the new version of tailwind, and the documentation is a bit outdated.

---
**Checklist**
- [X] Tested locally
- [ ] Added new dependencies
- [X] Updated the docs
- [ ] Added a test