### PR TITLE
Change twitter.com for x.com

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -151,7 +151,7 @@ const { version } = pkg
 
       <p>
         Created by <a
-          href='https://twitter.com/midudev'
+          href='https://x.com/midudev'
           target='_blank'
           rel='noopener noreferrer'>Midudev</a
         >


### PR DESCRIPTION
Dado el cambio de Twitter a X, el link https://twitter.com/midudev no funciona. Por ello, se cambia a https://x.com/midudev.

A veces el link de twitter.com funciona, pero otras veces no (no se muy bien porqué), pero el de x.com siempre funciona.