### PR TITLE
Add TypeScript declaration file for @midudev/tailwind-animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,6 @@
   },
   "peerDependencies": {
     "tailwindcss": "^3.0.0 || ^4.0.0"
-  }
+  },
+  "types": "./src/index.d.ts"
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,5 @@
+declare module "@midudev/tailwind-animations" {
+  import type { PluginCreator } from "tailwindcss/types/config";
+  const animations: PluginCreator;
+  export default animations;
+}


### PR DESCRIPTION
**What does this PR do?**

Adds a minimal TypeScript declaration file (`index.d.ts`) to declare the module `@midudev/tailwind-animations` as a valid Tailwind plugin.  
This removes the `Could not find a declaration file` (`ts(7016)`) error when using this plugin in TypeScript projects.

**Why are we doing this?**

Currently, the package does not include TypeScript types, and `@types/midudev__tailwind-animations` does not exist on DefinitelyTyped.  
Without a declaration, TypeScript users must manually add a custom module declaration in every project.  
This PR fixes it once and for all, and keeps compatibility with Tailwind CSS v3 and v4.

---

**Test Case(s):**

- Used this plugin in a `tailwind.config.ts` file.
- Verified that TypeScript recognizes the module with no `ts(7016)` error.
- Works with Tailwind CSS v3.4 and v4.x projects.

**Test Result(s):**

✅ No TypeScript errors  
✅ Plugin works as expected in the generated CSS  
✅ No impact on runtime behavior

---

**Checklist**
- [x] Tested locally
- [ ] Added new dependencies (N/A)
- [ ] Updated the docs (optional — not needed)
- [ ] Added a test (N/A for pure types)


##  Screenshots

### Before

| Screenshot | Description |
| ---------- | ------------ |
| <img width="1107" height="343" alt="image" src="https://github.com/user-attachments/assets/84a50668-56d3-4df2-a9cd-65bb59bb35e1" /> | `Could not find a declaration file` |

### After

| Screenshot | Description |
| ---------- | ------------ |
| <img width="949" height="362" alt="image" src="https://github.com/user-attachments/assets/9c5de7fa-fb63-4f51-90c8-d1b814ff0501" /> | `ts(7016)` error resolved |



