### PR TITLE
FIX: Heading tags hierarchy

### DIFF
--- a/web/src/components/layout/Footer.astro
+++ b/web/src/components/layout/Footer.astro
@@ -124,9 +124,9 @@ const FOOTER_LINKS = [
         {
           FOOTER_LINKS.map((section) => (
             <div class='flex flex-col gap-4'>
-              <h3 class='text-xs font-bold tracking-[0.2em] whitespace-nowrap text-slate-900 uppercase dark:text-white'>
+              <span class='text-xs font-bold tracking-[0.2em] whitespace-nowrap text-slate-900 uppercase dark:text-white'>
                 {section.title}
-              </h3>
+              </span>
               <ul class='flex flex-col gap-3'>
                 {section.links.map((link) => (
                   <li>

--- a/web/src/components/layout/Header.astro
+++ b/web/src/components/layout/Header.astro
@@ -69,11 +69,11 @@ import Enlace from '@components/ui/Enlace.astro'
         class='aspect-square size-7 shrink-0 sm:size-9'
         iconClass='size-4 sm:size-6 animate-float-subtle'
       />
-      <h1
+      <span
         class='text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl dark:text-white'
       >
         Tailwind <span class='text-blue-500'>Animations</span>
-      </h1>
+      </span>
     </div>
 
     <button


### PR DESCRIPTION
**What does this PR do?**

Replace the logo h1 with a span, and change the footer heading to a span too.

**Why are we doing this?**

For SEO optimization and better hierarchy

---
**Test Case(s):**

**Test Result(s):**

---
**Checklist**
- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated the docs
- [ ] Added a test