### PR TITLE
fix(layout): move Footer outside nested section element

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1552,9 +1552,9 @@ export default {
           </div>
         </div>
       </section>
-
-      <Footer />
     </section>
+
+    <Footer />
   </main>
 
   <style is:global>


### PR DESCRIPTION
## Summary
- Move the `Footer` component out of a nested `<section>` so it is a direct child of `<main>`.
- Fixes invalid semantic HTML where the footer was incorrectly placed inside a content section.

## Test plan
- [x] Open the homepage locally and verify the footer renders at the bottom as before
- [x] Inspect the DOM and confirm `<Footer />` is a sibling of the main content section, not nested inside it
- [x] Check that layout and spacing around the footer are unchanged