### PR TITLE
fix: show reduced-motion banner with opt-in override (fixes #89)

### DIFF
--- a/web/src/components/ui/ReducedMotionBanner.astro
+++ b/web/src/components/ui/ReducedMotionBanner.astro
@@ -1,0 +1,67 @@
+---
+---
+
+<div
+  id="reduced-motion-banner"
+  role="status"
+  aria-live="polite"
+  class="hidden items-center justify-between gap-3 rounded-xl border border-amber-400/30 bg-amber-400/10 px-4 py-3 text-sm text-amber-300"
+>
+  <span class="flex items-center gap-2">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+      <path d="M12 9v4" />
+      <path d="M12 17h.01" />
+    </svg>
+    <span>
+      Tu sistema tiene <strong>Reduce Motion</strong> activado. Las previews de animación están deshabilitadas.
+    </span>
+  </span>
+  <button
+    id="reduced-motion-dismiss"
+    type="button"
+    class="shrink-0 rounded-lg px-3 py-1 text-xs font-medium text-amber-200 ring-1 ring-amber-400/40 transition hover:bg-amber-400/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+    aria-label="Ignorar advertencia de movimiento reducido"
+  >
+    Ver de todas formas
+  </button>
+</div>
+
+<script>
+  const banner = document.getElementById('reduced-motion-banner')
+  const dismissBtn = document.getElementById('reduced-motion-dismiss')
+  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+
+  function showBanner() {
+    if (mediaQuery.matches && banner) {
+      banner.classList.remove('hidden')
+      banner.classList.add('flex')
+    }
+  }
+
+  dismissBtn?.addEventListener('click', () => {
+    banner?.classList.add('hidden')
+    banner?.classList.remove('flex')
+    document.documentElement.setAttribute('data-force-motion', 'true')
+
+    // notify cards so they can re-bind hover listeners
+    document.querySelectorAll('article[data-class]').forEach((article) => {
+      article.dispatchEvent(new Event('motionrestored'))
+    })
+  })
+
+  mediaQuery.addEventListener('change', showBanner)
+
+  showBanner()
+</script>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -72,4 +72,12 @@ const ogImage = `${siteUrl}/og.jpg`
       scroll-behavior: auto !important;
     }
   }
+
+  [data-force-motion='true'] *,
+  [data-force-motion='true'] *::before,
+  [data-force-motion='true'] *::after {
+    animation-duration: revert !important;
+    animation-iteration-count: revert !important;
+    transition-duration: revert !important;
+  }
 </style>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -16,6 +16,7 @@ import { Code } from 'astro:components'
 import CopyIcon from '@components/icons/copy.astro'
 
 import Logo from '@components/ui/Logo.astro'
+import ReducedMotionBanner from '@components/ui/ReducedMotionBanner.astro'
 
 // Importacion de componentes de layout
 import Footer from '@components/layout/Footer.astro'
@@ -630,6 +631,10 @@ export default {
             </label>
           </div>
         </section>
+
+        <div class='mx-auto max-w-6xl px-4 lg:px-8'>
+          <ReducedMotionBanner />
+        </div>
 
         <section
           class='relative mx-auto grid max-w-6xl grid-cols-2 gap-6 px-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 lg:px-8'


### PR DESCRIPTION
When prefers-reduced-motion: reduce is active, the CSS in Layout.astro correctly disables all animations — but the page gives no feedback. Cards still show the "Hover to preview" label, pointing to an interaction that silently does nothing. That's the confusion reported in #89.

This adds ReducedMotionBanner.astro, a small dismissible banner that:

1. Detects the media query on load and shows a plain explanatory message
2. Offers an opt-in button that re-enables animations for the session via data-force-motion on <html>, then dispatches a motionrestored event so cards can re-bind their listeners
3. Listens for runtime changes to the OS setting

The CSS override is scoped to [data-force-motion="true"] with revert so it only undoes what the existing reduced-motion rule applied — nothing else changes.

The pattern follows [WCAG 2.5.3](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions): respect the preference by default, allow explicit opt-in.

**Files changed**

- web/src/components/ui/ReducedMotionBanner.astro — new component
- web/src/layouts/Layout.astro — adds [data-force-motion] CSS rule
- web/src/pages/index.astro — renders the banner above the animation grid